### PR TITLE
Feat: 도서 상세 조회 기능 추가, 기타 기능 수정

### DIFF
--- a/backend/src/main/java/com/beb/backend/common/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/beb/backend/common/GlobalExceptionHandler.java
@@ -54,6 +54,12 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(info.getStatus()).body(BaseResponseDto.fail(info.getMessage()));
     }
 
+    @ExceptionHandler(OpenApiException.class)
+    public ResponseEntity<BaseResponseDto<Void>> handleOpenApiExceptions(OpenApiException e) {
+        OpenApiExceptionInfo info = e.getInfo();
+        return ResponseEntity.status(info.getStatus()).body(BaseResponseDto.fail(info.getMessage()));
+    }
+
     @ExceptionHandler(BadCredentialsException.class)
     public ResponseEntity<BaseResponseDto<Void>> handleBadCredentialsExceptions(BadCredentialsException e) {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(BaseResponseDto.fail("인증 실패"));

--- a/backend/src/main/java/com/beb/backend/common/ValidationRegexConstants.java
+++ b/backend/src/main/java/com/beb/backend/common/ValidationRegexConstants.java
@@ -8,4 +8,5 @@ public class ValidationRegexConstants {
     public static final String EMAIL_REGEX = "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}$";
     public static final String PASSWORD_REGEX = "^[a-zA-Z0-9!@#$%^&*]{8,20}$";
     public static final String NICKNAME_REGEX = "^[가-힣a-zA-Z0-9]{1,8}$";
+    public static final String ISBN_REGEX = "^[0-9]{13}$";
 }

--- a/backend/src/main/java/com/beb/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/beb/backend/config/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
                                 "/api/v1/users/email-availability",
                                 "/api/v1/users/nickname-availability",
                                 "/api/v1/books",
+                                "/api/v1/books/isbn/*",
                                 "/api/v1/reviews/{reviewId:\\d+}").permitAll()
                         .anyRequest().authenticated() // 나머지는 인증 필요
                 )

--- a/backend/src/main/java/com/beb/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/beb/backend/config/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
                                 "/api/v1/users/email-availability",
                                 "/api/v1/users/nickname-availability",
                                 "/api/v1/books",
+                                "/api/v1/books/*",
                                 "/api/v1/books/isbn/*",
                                 "/api/v1/reviews/{reviewId:\\d+}").permitAll()
                         .anyRequest().authenticated() // 나머지는 인증 필요

--- a/backend/src/main/java/com/beb/backend/config/WebClientConfig.java
+++ b/backend/src/main/java/com/beb/backend/config/WebClientConfig.java
@@ -14,7 +14,11 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class WebClientConfig {
 
-    private final Environment env;
+    @Value("${open-api.naver.client-id}")
+    private String CLIENT_ID;
+
+    @Value("${open-api.naver.client-secret}")
+    private String CLIENT_SECRET;
 
     @Value("${open-api.aladin.ttbkey}")
     private String TTBKEY;
@@ -22,8 +26,8 @@ public class WebClientConfig {
     @Bean("naverWebClient")
     public WebClient naverWebClient(WebClient.Builder builder) {
         return builder.baseUrl("https://openapi.naver.com/v1/search")
-                .defaultHeader("X-Naver-Client-Id", env.getProperty("open-api.naver.client-id"))
-                .defaultHeader("X-Naver-Client-Secret", env.getProperty("open-api.naver.client-secret"))
+                .defaultHeader("X-Naver-Client-Id", CLIENT_ID)
+                .defaultHeader("X-Naver-Client-Secret", CLIENT_SECRET)
                 .build();
     }
 

--- a/backend/src/main/java/com/beb/backend/config/WebClientConfig.java
+++ b/backend/src/main/java/com/beb/backend/config/WebClientConfig.java
@@ -1,16 +1,23 @@
 package com.beb.backend.config;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.DefaultUriBuilderFactory;
+
+import java.util.Map;
 
 @Configuration
 @RequiredArgsConstructor
 public class WebClientConfig {
 
     private final Environment env;
+
+    @Value("${open-api.aladin.ttbkey}")
+    private String TTBKEY;
 
     @Bean("naverWebClient")
     public WebClient naverWebClient(WebClient.Builder builder) {
@@ -22,6 +29,9 @@ public class WebClientConfig {
 
     @Bean("aladinWebClient")
     public WebClient aladinWebClient(WebClient.Builder builder) {
-        return builder.baseUrl("http://www.aladin.co.kr/ttb/api").build();
+        DefaultUriBuilderFactory factory = new DefaultUriBuilderFactory("http://www.aladin.co.kr/ttb/api");
+        factory.setDefaultUriVariables(Map.of("ttbkey", TTBKEY));
+
+        return builder.uriBuilderFactory(factory).build();
     }
 }

--- a/backend/src/main/java/com/beb/backend/controller/BookController.java
+++ b/backend/src/main/java/com/beb/backend/controller/BookController.java
@@ -30,11 +30,29 @@ public class BookController {
                 .body(bookService.searchBooksByNaverApi(query, page, size));
     }
 
+    /**
+     * ISBN 으로 도서 상세 정보 조회. DB에서 먼저 찾고, DB에 없을 경우는 알라딘 API를 호출하여 도서 정보를 받아와 DB에 저장 후 반환.
+     * GET 메서드이지만 DB에 쓰는 작업이 수행될 수 있다.
+     * 알라딘을 통한 검색 결과를 얻지 못했을 경우에 404 NOT FOUND 응답을 반환한다.
+     * @param isbn 도서 ISBN (13자리)
+     */
     @GetMapping("/isbn/{isbn}")
     public ResponseEntity<BaseResponseDto<BookAndUserStatusDto>>
     getBookDetailsByIsbn(@PathVariable @Pattern(regexp = ValidationRegexConstants.ISBN_REGEX) String isbn) {
         return ResponseEntity.status(HttpStatus.OK).body(
                 BaseResponseDto.success(bookService.getBookDetailsByIsbn(isbn), new BaseResponseDto.Meta("조회 성공"))
+        );
+    }
+
+    /**
+     * bookId 로 도서 상세 정보 조회. DB에 없을 경우 바로 404 NOT FOUND 응답을 반환한다.
+     * @param bookId 도서 PK
+     */
+    @GetMapping("/{bookId}")
+    public ResponseEntity<BaseResponseDto<BookAndUserStatusDto>>
+    getBookDetailsById(@PathVariable @Min(value = 1) Long bookId) {
+        return ResponseEntity.status(HttpStatus.OK).body(
+                BaseResponseDto.success(bookService.getBookDetailsById(bookId), new BaseResponseDto.Meta("조회 성공"))
         );
     }
 }

--- a/backend/src/main/java/com/beb/backend/controller/BookController.java
+++ b/backend/src/main/java/com/beb/backend/controller/BookController.java
@@ -1,19 +1,16 @@
 package com.beb.backend.controller;
 
-import com.beb.backend.dto.BaseResponseDto;
-import com.beb.backend.dto.BooksResponseDto;
-import com.beb.backend.dto.SearchBookInfoDto;
+import com.beb.backend.common.ValidationRegexConstants;
+import com.beb.backend.dto.*;
 import com.beb.backend.service.BookService;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -31,5 +28,13 @@ public class BookController {
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(bookService.searchBooksByNaverApi(query, page, size));
+    }
+
+    @GetMapping("/isbn/{isbn}")
+    public ResponseEntity<BaseResponseDto<BookAndUserStatusDto>>
+    getBookDetailsByIsbn(@PathVariable @Pattern(regexp = ValidationRegexConstants.ISBN_REGEX) String isbn) {
+        return ResponseEntity.status(HttpStatus.OK).body(
+                BaseResponseDto.success(bookService.getBookDetailsByIsbn(isbn), new BaseResponseDto.Meta("조회 성공"))
+        );
     }
 }

--- a/backend/src/main/java/com/beb/backend/controller/BookLogController.java
+++ b/backend/src/main/java/com/beb/backend/controller/BookLogController.java
@@ -29,7 +29,7 @@ public class BookLogController {
                             @RequestParam(defaultValue = "12") @Min(value = 1) int size) {
 
         Member member = memberService.getCurrentMember();
-        Pageable pageable = PageRequest.of(page - 1, size, Sort.by("createdAt").descending());
+        Pageable pageable = PageRequest.of(page - 1, size, Sort.by("readAt", "createdAt").descending());
         return ResponseEntity.status(HttpStatus.OK).body(
                 bookLogService.getUserReadBooksById(member, pageable)
         );

--- a/backend/src/main/java/com/beb/backend/domain/Category.java
+++ b/backend/src/main/java/com/beb/backend/domain/Category.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
+import java.util.Optional;
+
 @Entity
 @Table(name = "category",
 uniqueConstraints = @UniqueConstraint(columnNames = {"name", "parent_id", "mall_type"}))
@@ -27,6 +29,7 @@ public class Category {
     @Column(name = "mall_type", nullable = false)
     private MallType mallType;
 
+    @Getter
     public enum MallType {
         KOREAN_BOOK("국내도서"),
         FOREIGN_BOOK("외국도서");
@@ -37,8 +40,13 @@ public class Category {
             this.label = label;
         }
 
-        public String getLabel() {
-            return label;
+        public static Optional<MallType> valueOfLabel(String label) {
+            for (MallType mallType : MallType.values()) {
+                if (mallType.label.equals(label)) {
+                    return Optional.of(mallType);
+                }
+            }
+            return Optional.empty();
         }
     }
 }

--- a/backend/src/main/java/com/beb/backend/dto/AladinBookItemDto.java
+++ b/backend/src/main/java/com/beb/backend/dto/AladinBookItemDto.java
@@ -1,0 +1,18 @@
+package com.beb.backend.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.constraints.NotBlank;
+
+import java.time.LocalDate;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record AladinBookItemDto(
+        @NotBlank String title,
+        @NotBlank String author,
+        LocalDate pubDate,
+        String isbn13,
+        String cover,
+        String categoryName,
+        String publisher
+) {
+}

--- a/backend/src/main/java/com/beb/backend/dto/AladinBookSearchResponseDto.java
+++ b/backend/src/main/java/com/beb/backend/dto/AladinBookSearchResponseDto.java
@@ -1,0 +1,15 @@
+package com.beb.backend.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record AladinBookSearchResponseDto(
+        @NotNull Integer totalResults,
+        @NotNull Integer startIndex,
+        @NotNull Integer itemsPerPage,
+        @NotNull List<AladinBookItemDto> item
+) {
+}

--- a/backend/src/main/java/com/beb/backend/dto/BookAndUserStatusDto.java
+++ b/backend/src/main/java/com/beb/backend/dto/BookAndUserStatusDto.java
@@ -1,0 +1,11 @@
+package com.beb.backend.dto;
+
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record BookAndUserStatusDto(
+        BookDetailsDto book,
+        UserStatusDto userStatus
+) {
+}

--- a/backend/src/main/java/com/beb/backend/dto/BookDetailsDto.java
+++ b/backend/src/main/java/com/beb/backend/dto/BookDetailsDto.java
@@ -1,0 +1,33 @@
+package com.beb.backend.dto;
+
+import com.beb.backend.domain.Book;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record BookDetailsDto(
+        Long bookId,
+        String coverImgUrl,
+        String title,
+        String author,
+        String publisher,
+        LocalDate publishedDate,
+        String isbn,
+        Integer reviewCount,
+        BigDecimal averageRating
+) {
+
+    public static BookDetailsDto fromEntity(Book book) {
+        return new BookDetailsDto(
+                book.getId(),
+                book.getCoverImgUrl(),
+                book.getTitle(),
+                book.getAuthor(),
+                book.getPublisher(),
+                book.getPublishedDate(),
+                book.getIsbn(),
+                book.getReviewCount(),
+                book.getAverageRatingAsBigDecimal()
+        );
+    }
+}

--- a/backend/src/main/java/com/beb/backend/dto/BookSummaryWithRatingDto.java
+++ b/backend/src/main/java/com/beb/backend/dto/BookSummaryWithRatingDto.java
@@ -1,7 +1,0 @@
-package com.beb.backend.dto;
-
-import java.math.BigDecimal;
-
-public record BookSummaryWithRatingDto(Long bookId, String coverImgUrl,
-                                       String title, String author, BigDecimal averageRating) {
-}

--- a/backend/src/main/java/com/beb/backend/dto/CurrentUserReadBookDto.java
+++ b/backend/src/main/java/com/beb/backend/dto/CurrentUserReadBookDto.java
@@ -8,7 +8,7 @@ import java.time.LocalDateTime;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record CurrentUserReadBookDto(
         Long readBookId,
-        BookSummaryWithRatingDto book,
+        BookSummaryDto book,
         LocalDate readAt,
         LocalDateTime createdAt
 ) {

--- a/backend/src/main/java/com/beb/backend/dto/CurrentUserWishlistBookDto.java
+++ b/backend/src/main/java/com/beb/backend/dto/CurrentUserWishlistBookDto.java
@@ -4,7 +4,7 @@ import java.time.LocalDateTime;
 
 public record CurrentUserWishlistBookDto(
         Long wishlistBookId,
-        BookSummaryWithRatingDto book,
+        BookSummaryDto book,
         LocalDateTime createdAt
 ) {
 }

--- a/backend/src/main/java/com/beb/backend/dto/SearchBookInfoDto.java
+++ b/backend/src/main/java/com/beb/backend/dto/SearchBookInfoDto.java
@@ -1,5 +1,7 @@
 package com.beb.backend.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import java.math.BigDecimal;
 
 public record SearchBookInfoDto(
@@ -7,6 +9,7 @@ public record SearchBookInfoDto(
         String coverImgUrl,
         String title,
         String author,
+        @JsonInclude(JsonInclude.Include.NON_NULL) Long bookId,
         BigDecimal averageRating,
         Integer reviewCount
 ) {

--- a/backend/src/main/java/com/beb/backend/dto/UserStatusDto.java
+++ b/backend/src/main/java/com/beb/backend/dto/UserStatusDto.java
@@ -1,0 +1,8 @@
+package com.beb.backend.dto;
+
+public record UserStatusDto(
+        boolean isWishlist,
+        boolean isRead,
+        boolean hasReview
+) {
+}

--- a/backend/src/main/java/com/beb/backend/exception/BookLogExceptionInfo.java
+++ b/backend/src/main/java/com/beb/backend/exception/BookLogExceptionInfo.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 public enum BookLogExceptionInfo {
     DUPLICATE_READ_BOOK(HttpStatus.BAD_REQUEST, "이미 읽은 책에 저장된 정보"),
     READ_BOOK_NOT_FOUND(HttpStatus.NOT_FOUND, "읽은 책 목록에 해당 도서가 존재하지 않음"),
+    CANNOT_ADD_READ_BOOK_TO_WISHLIST_BOOK(HttpStatus.BAD_REQUEST, "읽은 책을 찜한 책에 저장할 수 없음"),
     DUPLICATE_WISHLIST_BOOK(HttpStatus.BAD_REQUEST, "이미 찜한 책에 저장된 정보"),
     WISHLIST_BOOK_NOT_FOUND(HttpStatus.NOT_FOUND, "찜한 책 목록에 해당 도서가 존재하지 않음"),
     REVIEW_NOT_PUBLIC(HttpStatus.FORBIDDEN, "비공개 설정된 리뷰"),

--- a/backend/src/main/java/com/beb/backend/exception/BookLogExceptionInfo.java
+++ b/backend/src/main/java/com/beb/backend/exception/BookLogExceptionInfo.java
@@ -7,9 +7,11 @@ import org.springframework.http.HttpStatus;
 public enum BookLogExceptionInfo {
     DUPLICATE_READ_BOOK(HttpStatus.BAD_REQUEST, "이미 읽은 책에 저장된 정보"),
     READ_BOOK_NOT_FOUND(HttpStatus.NOT_FOUND, "읽은 책 목록에 해당 도서가 존재하지 않음"),
+    READ_BOOK_FORBIDDEN(HttpStatus.FORBIDDEN, "읽은 책 기록에 대한 권한 없음"),
     CANNOT_ADD_READ_BOOK_TO_WISHLIST_BOOK(HttpStatus.BAD_REQUEST, "읽은 책을 찜한 책에 저장할 수 없음"),
     DUPLICATE_WISHLIST_BOOK(HttpStatus.BAD_REQUEST, "이미 찜한 책에 저장된 정보"),
     WISHLIST_BOOK_NOT_FOUND(HttpStatus.NOT_FOUND, "찜한 책 목록에 해당 도서가 존재하지 않음"),
+    WISHLIST_BOOK_FORBIDDEN(HttpStatus.FORBIDDEN, "찜한 책 기록에 대한 권한 없음"),
     REVIEW_NOT_PUBLIC(HttpStatus.FORBIDDEN, "비공개 설정된 리뷰"),
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 리뷰가 존재하지 않음"),
     REVIEW_FORBIDDEN(HttpStatus.FORBIDDEN, "리뷰에 대한 권한 없음");

--- a/backend/src/main/java/com/beb/backend/exception/OpenApiException.java
+++ b/backend/src/main/java/com/beb/backend/exception/OpenApiException.java
@@ -1,0 +1,10 @@
+package com.beb.backend.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class OpenApiException extends RuntimeException {
+    private final OpenApiExceptionInfo info;
+}

--- a/backend/src/main/java/com/beb/backend/exception/OpenApiExceptionInfo.java
+++ b/backend/src/main/java/com/beb/backend/exception/OpenApiExceptionInfo.java
@@ -1,0 +1,18 @@
+package com.beb.backend.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum OpenApiExceptionInfo {
+    API_CALL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "외부 API 호출 에러"),
+    ALADIN_BOOK_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 도서가 존재하지 않음");
+
+    private final HttpStatus status;
+    private final String message;
+
+    OpenApiExceptionInfo(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+}

--- a/backend/src/main/java/com/beb/backend/repository/CategoryRepository.java
+++ b/backend/src/main/java/com/beb/backend/repository/CategoryRepository.java
@@ -1,23 +1,18 @@
 package com.beb.backend.repository;
 
 import com.beb.backend.domain.Category;
+import jakarta.validation.constraints.NotNull;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Optional;
+
 public interface CategoryRepository extends JpaRepository<Category, Long> {
-    @Query("select count(c) > 0 from Category c "
-            + "where c.name = :name and c.parentCategory.id = :parentId and c.mallType = :mallType")
-    boolean existsByNameAndParentIdAndMallType(@Param("name") String name,
-                                               @Param("parentId") Long parentId,
-                                               @Param("mallType") Category.MallType mallType);
+    @Query("SELECT c from Category c "
+            + "WHERE c.parentCategory IS NULL AND c.name = :name AND c.mallType = :mallType")
+    Optional<Category> findRootCategoryByNameAndMallType(@Param("name") String name,
+                                                         @Param("mallType") Category.MallType mallType);
 
-    @Query("select c.id from Category c "
-            + "where c.parentCategory is null and c.name = :name and c.mallType = :mallType")
-    Long findRootCategoryIdByNameAndMallType(@Param("name") String name,
-                                             @Param("mallType") Category.MallType mallType);
-
-    @Query("select c.id from Category c "
-            + "where c.name = :name and c.parentCategory.id = :parentId")
-    Long findCategoryIdByNameAndParentId(@Param("name") String name, @Param("parentId") Long parentId);
+    Optional<Category> findCategoryByNameAndParentCategory(@NotNull String name, Category parentCategory);
 }

--- a/backend/src/main/java/com/beb/backend/repository/CommentRepository.java
+++ b/backend/src/main/java/com/beb/backend/repository/CommentRepository.java
@@ -1,6 +1,8 @@
 package com.beb.backend.repository;
 
+import com.beb.backend.domain.Book;
 import com.beb.backend.domain.Comment;
+import com.beb.backend.domain.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -21,4 +23,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     // 특정 리뷰에 달린 댓글 조회
     @Query("SELECT c FROM Comment c WHERE c.parentComment.id = :reviewId")
     List<Comment> findCommentsByParentReviewId(@Param("reviewId") Long reviewId);
+
+    boolean existsByMemberAndBookAndParentCommentIsNull(Member member, Book book);
 }

--- a/backend/src/main/java/com/beb/backend/repository/CommentRepository.java
+++ b/backend/src/main/java/com/beb/backend/repository/CommentRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     // 특정 Member가 작성한 리뷰 조회
@@ -23,6 +24,8 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     // 특정 리뷰에 달린 댓글 조회
     @Query("SELECT c FROM Comment c WHERE c.parentComment.id = :reviewId")
     List<Comment> findCommentsByParentReviewId(@Param("reviewId") Long reviewId);
+
+    Optional<Comment> findByMemberAndBookAndParentCommentIsNull(Member member, Book book);
 
     boolean existsByMemberAndBookAndParentCommentIsNull(Member member, Book book);
 }

--- a/backend/src/main/java/com/beb/backend/repository/WishlistBookRepository.java
+++ b/backend/src/main/java/com/beb/backend/repository/WishlistBookRepository.java
@@ -8,11 +8,14 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.CrudRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface WishlistBookRepository extends CrudRepository<WishlistBook, Long> {
     List<WishlistBook> findByMember(Member member);
     Page<WishlistBook> findByMember(Member member, Pageable pageable);
     List<WishlistBook> findByBook(Book book);
+
+    Optional<WishlistBook> findByMemberAndBook(Member member, Book book);
 
     boolean existsByMemberAndBook(Member member, Book book);
 }

--- a/backend/src/main/java/com/beb/backend/service/BookLogService.java
+++ b/backend/src/main/java/com/beb/backend/service/BookLogService.java
@@ -13,8 +13,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -30,18 +28,13 @@ public class BookLogService {
 
 
     private CurrentUserReadBookDto mapToCurrentUserReadBookDto(ReadBook readBook) {
-        BigDecimal decimalRating = Optional.ofNullable(readBook.getBook().getAverageRating())
-                .map(avg -> BigDecimal.valueOf(avg).setScale(1, RoundingMode.HALF_UP))
-                .orElse(null);
-
         return new CurrentUserReadBookDto(
                 readBook.getId(),
-                new BookSummaryWithRatingDto(
+                new BookSummaryDto(
                         readBook.getBook().getId(),
                         readBook.getBook().getCoverImgUrl(),
                         readBook.getBook().getTitle(),
-                        readBook.getBook().getAuthor(),
-                        decimalRating
+                        readBook.getBook().getAuthor()
                 ),
                 readBook.getReadAt(),
                 readBook.getCreatedAt()
@@ -89,18 +82,13 @@ public class BookLogService {
     }
 
     private CurrentUserWishlistBookDto mapToCurrentUserWishlistBookDto(WishlistBook wishlistBook) {
-        BigDecimal decimalRating = Optional.ofNullable(wishlistBook.getBook().getAverageRating())
-                .map(avg -> BigDecimal.valueOf(avg).setScale(1, RoundingMode.HALF_UP))
-                .orElse(null);
-
         return new CurrentUserWishlistBookDto(
                 wishlistBook.getId(),
-                new BookSummaryWithRatingDto(
+                new BookSummaryDto(
                         wishlistBook.getBook().getId(),
                         wishlistBook.getBook().getCoverImgUrl(),
                         wishlistBook.getBook().getTitle(),
-                        wishlistBook.getBook().getAuthor(),
-                        decimalRating
+                        wishlistBook.getBook().getAuthor()
                 ),
                 wishlistBook.getCreatedAt()
         );

--- a/backend/src/main/java/com/beb/backend/service/BookLogService.java
+++ b/backend/src/main/java/com/beb/backend/service/BookLogService.java
@@ -75,6 +75,9 @@ public class BookLogService {
                 .book(book.get())
                 .readAt(request.readAt()).build();
         readBookRepository.save(readBook);
+
+        wishlistBookRepository.findByMemberAndBook(member, book.get())
+                .ifPresent(wishlistBookRepository::delete);
     }
 
     @Transactional

--- a/backend/src/main/java/com/beb/backend/service/BookLogService.java
+++ b/backend/src/main/java/com/beb/backend/service/BookLogService.java
@@ -255,4 +255,22 @@ public class BookLogService {
         commentRepository.delete(review);
         book.decrementReviewCount();
     }
+
+    /**
+     * 현재 사용자가 입력된 책을 찜한 책으로 등록했는지, 읽은 책으로 등록했는지, 책에 대한 리뷰를 작성했는지에 대한 정보를 반환
+     * 인증되지 않은 사용자는 빈 Optional로 반환
+     * @param book (Book) 확인할 도서 객체
+     */
+    public Optional<UserStatusDto> getCurrentUserStatusAboutBook(Book book) {
+        try {
+            Member member = memberService.getCurrentMember();
+            return Optional.of(new UserStatusDto(
+                    wishlistBookRepository.existsByMemberAndBook(member, book),
+                    readBookRepository.existsByMemberAndBook(member, book),
+                    commentRepository.existsByMemberAndBookAndParentCommentIsNull(member, book)
+            ));
+        } catch (MemberException e) {
+            return Optional.empty();
+        }
+    }
 }

--- a/backend/src/main/java/com/beb/backend/service/BookLogService.java
+++ b/backend/src/main/java/com/beb/backend/service/BookLogService.java
@@ -126,6 +126,9 @@ public class BookLogService {
         if (book.isEmpty()) throw new BookException(BookExceptionInfo.BOOK_NOT_FOUND);
 
         Member member = memberService.getCurrentMember();
+        if (readBookRepository.existsByMemberAndBook(member, book.get())) {
+            throw new BookLogException(BookLogExceptionInfo.CANNOT_ADD_READ_BOOK_TO_WISHLIST_BOOK);
+        }
         if (wishlistBookRepository.existsByMemberAndBook(member, book.get())) {
             throw new BookLogException(BookLogExceptionInfo.DUPLICATE_WISHLIST_BOOK);
         }

--- a/backend/src/main/java/com/beb/backend/service/BookService.java
+++ b/backend/src/main/java/com/beb/backend/service/BookService.java
@@ -3,6 +3,8 @@ package com.beb.backend.service;
 import com.beb.backend.domain.Book;
 import com.beb.backend.domain.Category;
 import com.beb.backend.dto.*;
+import com.beb.backend.exception.BookException;
+import com.beb.backend.exception.BookExceptionInfo;
 import com.beb.backend.exception.OpenApiException;
 import com.beb.backend.exception.OpenApiExceptionInfo;
 import com.beb.backend.repository.BookRepository;
@@ -167,6 +169,16 @@ public class BookService {
         return new BookAndUserStatusDto(
                 BookDetailsDto.fromEntity(savedBook),
                 bookLogService.getCurrentUserStatusAboutBook(savedBook).orElse(null)
+        );
+    }
+
+    @Transactional
+    public BookAndUserStatusDto getBookDetailsById(Long bookId) {
+        Book book = bookRepository.findById(bookId)
+                .orElseThrow(() -> new BookException(BookExceptionInfo.BOOK_NOT_FOUND));
+        return new BookAndUserStatusDto(
+                BookDetailsDto.fromEntity(book),
+                bookLogService.getCurrentUserStatusAboutBook(book).orElse(null)
         );
     }
 }

--- a/backend/src/main/java/com/beb/backend/service/BookService.java
+++ b/backend/src/main/java/com/beb/backend/service/BookService.java
@@ -82,6 +82,7 @@ public class BookService {
                             item.image(),
                             item.title(),
                             item.author(),
+                            book.map(Book::getId).orElse(null),
                             book.map(Book::getAverageRatingAsBigDecimal).orElse(null),
                             book.map(Book::getReviewCount).orElse(0)
                     );

--- a/backend/src/main/java/com/beb/backend/service/CategoryService.java
+++ b/backend/src/main/java/com/beb/backend/service/CategoryService.java
@@ -1,0 +1,46 @@
+package com.beb.backend.service;
+
+import com.beb.backend.domain.Category;
+import com.beb.backend.repository.CategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+
+    private final CategoryRepository categoryRepository;
+
+
+    private Optional<Category> findForeignDetailCategory(String firstDepth, String secondDepth) {
+        Optional<Category> rootCategory = categoryRepository
+                .findRootCategoryByNameAndMallType(firstDepth, Category.MallType.FOREIGN_BOOK);
+
+        if (rootCategory.isPresent()) {
+            return categoryRepository
+                    .findCategoryByNameAndParentCategory(secondDepth, rootCategory.get())
+                    .or(() -> rootCategory);
+        }
+        return rootCategory;
+    }
+
+    /**
+     * 알라딘 API로부터 오는 카테고리명으로부터 DB에 저장된 Category 객체를 찾아 DB에 있으면 반환, 없으면 빈 Optional 반환
+     * @param categoryName 알라딘 API 응답의 categoryName
+     */
+    public Optional<Category> findCategoryByCategoryName(String categoryName) {
+        String[] categories = categoryName.split(">");
+        if (categories.length <= 1) return Optional.empty();
+
+        Optional<Category.MallType> mallType = Category.MallType.valueOfLabel(categories[0]);
+        if (mallType.isEmpty()) return Optional.empty();
+
+        if (mallType.get().getLabel().equals("국내도서") || categories.length == 2) { // 최상위 카테고리만 존재
+            return categoryRepository.findRootCategoryByNameAndMallType(categories[1], mallType.get());
+        } else {    // 외국도서 중 세부 카테고리 존재할 수 있는 경우
+            return findForeignDetailCategory(categories[1], categories[2]);
+        }
+    }
+}


### PR DESCRIPTION
### 1️⃣ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
<br>

### 2️⃣ 이슈 번호
close #41 #44 
<br>
<br>

### 3️⃣ 변경 사항

#### 추가된 기능
- 도서 상세 정보 조회 기능 추가
  - 2가지 버전: ISBN으로 조회, bookId로 조회
  - 네이버 api를 통한 검색 결과 목록을 조회 후 상세 조회로 넘어갈 때, DB에 저장되어 있지 않은 책은 bookId를 이용할 수 없어 ISBN 조회를 기본으로 하고 bookId는 보조 수단으로 구현
  - 자세한 것은 #41 , [도서 상세 정보 조회 노션 api 명세](https://www.notion.so/ISBN-14591c17c5908151943be8691cbcbbf1) 참고

#### 수정된 기능
- 읽은 책 관련 기능 수정
  - 등록 기능: 읽은 책 등록 시, 찜한 책에 등록된 책이면 찜한 책에서는 삭제하는 로직 추가
  - 삭제 기능: 읽은 책 삭제 시, 삭제 요청자가 해당 기록 작성자인지 확인하는 로직 추가(권한 없으면 403 반환), 그 책에 대한 해당 사용자의 리뷰가 있을 경우 리뷰도 삭제하도록 함
  - 조회 기능: 정렬 기준 변경(readAt을 createdAt보다 우선), 응답에서 book.averageRating 항목 삭제

- 찜한 책 관련 기능 수정
  - 등록 기능: 읽은 책을 찜한 책에 등록하려고 할 경우, 400 에러 반환하도록 함
  - 삭제 기능: 찜한 책 삭제 시, 삭제 요청자가 해당 기록 작성자인지 확인하는 로직 추가(권한 없으면 403 반환)
  - 조회 기능: 응답에서 book.averageRating 항목 삭제

- 도서 검색 결과 조회 기능 수정
  - 응답에 bookId 항목 추가: 검색 결과로 나온 책들 중 DB에 존재하는 책들은 bookId를 넣어서 반환.
  - bookId가 있는 책에 대해서는 bookId를 통한 도서 상세 정보 조회가 가능하도록 함.
<br>
<br>

### 4️⃣ 테스트 결과

