### PR TITLE
Feat: 프로필 사진 저장, 수정 기능 추가 

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -33,6 +33,8 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+	// AWS S3
+	implementation "software.amazon.awssdk:s3:2.29.0"
 	//
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/backend/src/main/java/com/beb/backend/common/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/beb/backend/common/GlobalExceptionHandler.java
@@ -60,6 +60,12 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(info.getStatus()).body(BaseResponseDto.fail(info.getMessage()));
     }
 
+    @ExceptionHandler(AwsS3Exception.class)
+    public ResponseEntity<BaseResponseDto<Void>> handleAwsS3Exceptions(AwsS3Exception e) {
+        AwsS3ExceptionInfo info = e.getInfo();
+        return ResponseEntity.status(info.getStatus()).body(BaseResponseDto.fail(info.getMessage()));
+    }
+
     @ExceptionHandler(BadCredentialsException.class)
     public ResponseEntity<BaseResponseDto<Void>> handleBadCredentialsExceptions(BadCredentialsException e) {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(BaseResponseDto.fail("인증 실패"));

--- a/backend/src/main/java/com/beb/backend/config/AwsS3Config.java
+++ b/backend/src/main/java/com/beb/backend/config/AwsS3Config.java
@@ -1,0 +1,28 @@
+package com.beb.backend.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class AwsS3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String AWS_ACCESS_KEY;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String AWS_SECRET_KEY;
+
+    @Bean
+    public S3Client AwsS3Client() {
+        AwsCredentials credentials = AwsBasicCredentials.create(AWS_ACCESS_KEY, AWS_SECRET_KEY);
+        return S3Client.builder()
+                .region(Region.AP_NORTHEAST_2)
+                .credentialsProvider(StaticCredentialsProvider.create(credentials)).build();
+    }
+}

--- a/backend/src/main/java/com/beb/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/beb/backend/config/SecurityConfig.java
@@ -46,6 +46,10 @@ public class SecurityConfig {
                                 "/api/v1/books/*/reviews",
                                 "/api/v1/books/isbn/*",
                                 "/api/v1/reviews/{reviewId:\\d+}").permitAll()
+                        .requestMatchers(HttpMethod.POST,
+                                "/api/v1/users/img").permitAll()
+                        .requestMatchers(HttpMethod.DELETE,
+                                "/api/v1/users/img").permitAll()
                         .anyRequest().authenticated() // 나머지는 인증 필요
                 )
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))

--- a/backend/src/main/java/com/beb/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/beb/backend/config/SecurityConfig.java
@@ -46,10 +46,6 @@ public class SecurityConfig {
                                 "/api/v1/books/*/reviews",
                                 "/api/v1/books/isbn/*",
                                 "/api/v1/reviews/{reviewId:\\d+}").permitAll()
-                        .requestMatchers(HttpMethod.POST,
-                                "/api/v1/users/img").permitAll()
-                        .requestMatchers(HttpMethod.DELETE,
-                                "/api/v1/users/img").permitAll()
                         .anyRequest().authenticated() // 나머지는 인증 필요
                 )
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))

--- a/backend/src/main/java/com/beb/backend/controller/MemberController.java
+++ b/backend/src/main/java/com/beb/backend/controller/MemberController.java
@@ -28,15 +28,17 @@ public class MemberController {
 
     /**
      * 입력된 정보로 회원을 생성하고 액세스 토큰과 리프레시 토큰을 반환
-     * @param request (MemberSignUpRequestDto)
+     * @param request (SignUpRequestDto) 가입할 회원 정보
+     * @param profileImg (MultipartFile) 프로필 이미지 파일
      */
     @PostMapping("/signup")
     public ResponseEntity<BaseResponseDto<TokenResponseDto>> signUp(
-            @RequestBody @Valid SignUpRequestDto request) {
-        TokenResponseDto tokenResponse = memberService.signUp(request);
-        BaseResponseDto<TokenResponseDto> response = BaseResponseDto.success(
-                tokenResponse, new BaseResponseDto.Meta("회원 가입 성공"));
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+            @RequestPart("userInfo") @Valid SignUpRequestDto request,
+            @RequestPart(value = "profileImg", required = false) MultipartFile profileImg) {
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(BaseResponseDto.success(
+                memberService.signUp(request, profileImg), new BaseResponseDto.Meta("회원 가입 성공"))
+        );
     }
 
     /**
@@ -152,23 +154,5 @@ public class MemberController {
     public ResponseEntity<BaseResponseDto<Void>> updateUserProfile(@RequestBody @Valid UpdateProfileRequestDto request) {
         memberService.updateUserProfile(request);
         return ResponseEntity.status(HttpStatus.OK).body(BaseResponseDto.emptySuccess("프로필 수정 성공"));
-    }
-
-    @PostMapping("/img")
-    public ResponseEntity<BaseResponseDto<Void>> tempUploadImg(@RequestPart("profileImg")MultipartFile profileImg) {
-
-        String bucketName = "test-beb-bucket-01";
-        String key = "temp/" + profileImg.getOriginalFilename();
-
-        awsS3Service.uploadFile(bucketName, key, profileImg);
-        return ResponseEntity.status(HttpStatus.OK).body(BaseResponseDto.emptySuccess("파일 업로드 성공"));
-    }
-
-    @DeleteMapping("/img")
-    public ResponseEntity<BaseResponseDto<Void>> tempDeleteImg(@RequestParam String fileUrl) {
-
-        String bucketName = "test-beb-bucket-01";
-        awsS3Service.deleteFile(bucketName, fileUrl);
-        return ResponseEntity.status(HttpStatus.OK).body(BaseResponseDto.emptySuccess("파일 삭제 성공"));
     }
 }

--- a/backend/src/main/java/com/beb/backend/controller/MemberController.java
+++ b/backend/src/main/java/com/beb/backend/controller/MemberController.java
@@ -4,7 +4,6 @@ import com.beb.backend.common.ValidationRegexConstants;
 import com.beb.backend.dto.*;
 import com.beb.backend.exception.MemberException;
 import com.beb.backend.exception.MemberExceptionInfo;
-import com.beb.backend.service.AwsS3Service;
 import com.beb.backend.service.MemberService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
@@ -24,7 +23,6 @@ import org.springframework.web.multipart.MultipartFile;
 public class MemberController {
 
     private final MemberService memberService;
-    private final AwsS3Service awsS3Service;
 
     /**
      * 입력된 정보로 회원을 생성하고 액세스 토큰과 리프레시 토큰을 반환
@@ -148,11 +146,15 @@ public class MemberController {
 
     /**
      * 현재 인증된 사용자의 프로필 정보를 입력 받은 정보로 수정. 입력된 항목만 수정한다.
-     * @param request (UpdateProfileRequestDto)
+     * @param userInfo (UpdateProfileRequestDto) 수정할 회원 정보
+     * @param profileImg (MultipartFile) 프로필 사진 파일
      */
     @PutMapping("/me")
-    public ResponseEntity<BaseResponseDto<Void>> updateUserProfile(@RequestBody @Valid UpdateProfileRequestDto request) {
-        memberService.updateUserProfile(request);
+    public ResponseEntity<BaseResponseDto<Void>> updateUserProfile(
+            @RequestPart("userInfo") @Valid UpdateProfileRequestDto userInfo,
+            @RequestPart(value = "profileImg", required = false) MultipartFile profileImg) {
+
+        memberService.updateUserProfile(userInfo, profileImg);
         return ResponseEntity.status(HttpStatus.OK).body(BaseResponseDto.emptySuccess("프로필 수정 성공"));
     }
 }

--- a/backend/src/main/java/com/beb/backend/controller/MemberController.java
+++ b/backend/src/main/java/com/beb/backend/controller/MemberController.java
@@ -4,6 +4,7 @@ import com.beb.backend.common.ValidationRegexConstants;
 import com.beb.backend.dto.*;
 import com.beb.backend.exception.MemberException;
 import com.beb.backend.exception.MemberExceptionInfo;
+import com.beb.backend.service.AwsS3Service;
 import com.beb.backend.service.MemberService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
@@ -14,6 +15,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,6 +24,7 @@ import org.springframework.web.bind.annotation.*;
 public class MemberController {
 
     private final MemberService memberService;
+    private final AwsS3Service awsS3Service;
 
     /**
      * 입력된 정보로 회원을 생성하고 액세스 토큰과 리프레시 토큰을 반환
@@ -149,5 +152,23 @@ public class MemberController {
     public ResponseEntity<BaseResponseDto<Void>> updateUserProfile(@RequestBody @Valid UpdateProfileRequestDto request) {
         memberService.updateUserProfile(request);
         return ResponseEntity.status(HttpStatus.OK).body(BaseResponseDto.emptySuccess("프로필 수정 성공"));
+    }
+
+    @PostMapping("/img")
+    public ResponseEntity<BaseResponseDto<Void>> tempUploadImg(@RequestPart("profileImg")MultipartFile profileImg) {
+
+        String bucketName = "test-beb-bucket-01";
+        String key = "temp/" + profileImg.getOriginalFilename();
+
+        awsS3Service.uploadFile(bucketName, key, profileImg);
+        return ResponseEntity.status(HttpStatus.OK).body(BaseResponseDto.emptySuccess("파일 업로드 성공"));
+    }
+
+    @DeleteMapping("/img")
+    public ResponseEntity<BaseResponseDto<Void>> tempDeleteImg(@RequestParam String fileUrl) {
+
+        String bucketName = "test-beb-bucket-01";
+        awsS3Service.deleteFile(bucketName, fileUrl);
+        return ResponseEntity.status(HttpStatus.OK).body(BaseResponseDto.emptySuccess("파일 삭제 성공"));
     }
 }

--- a/backend/src/main/java/com/beb/backend/domain/Member.java
+++ b/backend/src/main/java/com/beb/backend/domain/Member.java
@@ -50,8 +50,8 @@ public class Member {   // 회원
     @Column(name = "gender", nullable = false) // 성별 (M, F)
     private Gender gender;
 
-    @Column(name = "profile_img_path")
-    private String profileImgPath;
+    @Column(name = "profile_img_key")
+    private String profileImgKey;
 
     @NotNull
     @CreatedDate
@@ -63,12 +63,12 @@ public class Member {   // 회원
     }
 
     @Builder
-    public Member(String email, String password, String nickname, Integer age, Gender gender, String profileImgPath) {
+    public Member(String email, String password, String nickname, Integer age, Gender gender, String profileImgKey) {
         this.email = email;
         this.password = password;
         this.nickname = nickname;
         this.age = age;
         this.gender = gender;
-        this.profileImgPath = profileImgPath;
+        this.profileImgKey = profileImgKey;
     }
 }

--- a/backend/src/main/java/com/beb/backend/dto/FullProfileDto.java
+++ b/backend/src/main/java/com/beb/backend/dto/FullProfileDto.java
@@ -7,4 +7,4 @@ public record FullProfileDto(
         String nickname,
         Integer age,
         Member.Gender gender,
-        String profileImgPath) implements ProfileResponseDto{ }
+        String profileImgUrl) implements ProfileResponseDto{ }

--- a/backend/src/main/java/com/beb/backend/dto/PublicProfileDto.java
+++ b/backend/src/main/java/com/beb/backend/dto/PublicProfileDto.java
@@ -2,5 +2,5 @@ package com.beb.backend.dto;
 
 public record PublicProfileDto(
         String nickname,
-        String profileImgPath) implements ProfileResponseDto{
+        String profileImgUrl) implements ProfileResponseDto{
 }

--- a/backend/src/main/java/com/beb/backend/dto/SignUpRequestDto.java
+++ b/backend/src/main/java/com/beb/backend/dto/SignUpRequestDto.java
@@ -29,7 +29,5 @@ public record SignUpRequestDto(
         Integer age,
 
         @NotNull @Enumerated(EnumType.STRING)
-        Member.Gender gender,
-
-        String profileImgPath
+        Member.Gender gender
 ) { }

--- a/backend/src/main/java/com/beb/backend/dto/UpdateProfileRequestDto.java
+++ b/backend/src/main/java/com/beb/backend/dto/UpdateProfileRequestDto.java
@@ -23,6 +23,7 @@ public record UpdateProfileRequestDto(
         @Enumerated(EnumType.STRING)
         Member.Gender gender,
 
-        String profileImgPath
+        @Pattern(regexp = "DELETE|UPDATE", flags = Pattern.Flag.CASE_INSENSITIVE)
+        String profileImgAction
 ) {
 }

--- a/backend/src/main/java/com/beb/backend/exception/AwsS3Exception.java
+++ b/backend/src/main/java/com/beb/backend/exception/AwsS3Exception.java
@@ -1,0 +1,10 @@
+package com.beb.backend.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AwsS3Exception extends RuntimeException {
+    private final AwsS3ExceptionInfo info;
+}

--- a/backend/src/main/java/com/beb/backend/exception/AwsS3ExceptionInfo.java
+++ b/backend/src/main/java/com/beb/backend/exception/AwsS3ExceptionInfo.java
@@ -1,0 +1,18 @@
+package com.beb.backend.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum AwsS3ExceptionInfo {
+    FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드 실패"),
+    FILE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 삭제 실패");
+
+    private final HttpStatus status;
+    private final String message;
+
+    AwsS3ExceptionInfo(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+}

--- a/backend/src/main/java/com/beb/backend/exception/AwsS3ExceptionInfo.java
+++ b/backend/src/main/java/com/beb/backend/exception/AwsS3ExceptionInfo.java
@@ -5,8 +5,8 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum AwsS3ExceptionInfo {
-    FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드 실패"),
-    FILE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 삭제 실패");
+    S3_FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3 파일 업로드 실패"),
+    S3_FILE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3 파일 삭제 실패");
 
     private final HttpStatus status;
     private final String message;

--- a/backend/src/main/java/com/beb/backend/exception/ProfileImgException.java
+++ b/backend/src/main/java/com/beb/backend/exception/ProfileImgException.java
@@ -1,0 +1,10 @@
+package com.beb.backend.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ProfileImgException extends RuntimeException {
+    private final ProfileImgExceptionInfo info;
+}

--- a/backend/src/main/java/com/beb/backend/exception/ProfileImgExceptionInfo.java
+++ b/backend/src/main/java/com/beb/backend/exception/ProfileImgExceptionInfo.java
@@ -7,7 +7,8 @@ import org.springframework.http.HttpStatus;
 public enum ProfileImgExceptionInfo {
     NULL_OR_EMPTY_FILE(HttpStatus.BAD_REQUEST, "빈 파일"),
     INVALID_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "유효하지 않은 파일 확장자"),
-    FILE_SIZE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "파일 허용 크기 초과");
+    FILE_SIZE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "파일 허용 크기 초과"),
+    UPDATE_PROFILE_IMG_BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청");
 
     private final HttpStatus status;
     private final String message;

--- a/backend/src/main/java/com/beb/backend/exception/ProfileImgExceptionInfo.java
+++ b/backend/src/main/java/com/beb/backend/exception/ProfileImgExceptionInfo.java
@@ -1,0 +1,19 @@
+package com.beb.backend.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ProfileImgExceptionInfo {
+    NULL_OR_EMPTY_FILE(HttpStatus.BAD_REQUEST, "빈 파일"),
+    INVALID_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "유효하지 않은 파일 확장자"),
+    FILE_SIZE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "파일 허용 크기 초과");
+
+    private final HttpStatus status;
+    private final String message;
+
+    ProfileImgExceptionInfo(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+}

--- a/backend/src/main/java/com/beb/backend/service/AwsS3Service.java
+++ b/backend/src/main/java/com/beb/backend/service/AwsS3Service.java
@@ -1,0 +1,62 @@
+package com.beb.backend.service;
+
+import com.beb.backend.exception.AwsS3Exception;
+import com.beb.backend.exception.AwsS3ExceptionInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@Service
+@RequiredArgsConstructor
+public class AwsS3Service {
+
+    private final S3Client awsS3Client;
+
+    public void uploadFile(String bucketName, String filePath, MultipartFile multipartFile){
+        try {
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(filePath)
+                    .contentType(multipartFile.getContentType())
+                    .build();
+
+            RequestBody requestBody = RequestBody.fromInputStream(multipartFile.getInputStream(), multipartFile.getSize());
+
+            awsS3Client.putObject(putObjectRequest, requestBody);
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            throw new AwsS3Exception(AwsS3ExceptionInfo.FILE_UPLOAD_FAILED);
+        }
+    }
+
+    private String extractKeyFromUrl(String bucketName, String fileUrl) {
+        // 버킷 URL 구성
+        String bucketUrl = "https://" + bucketName + ".s3.ap-northeast-2.amazonaws.com/";
+
+        // URL에서 Key 추출
+        if (fileUrl.startsWith(bucketUrl)) {
+            return fileUrl.substring(bucketUrl.length());
+        } else {
+            throw new IllegalArgumentException("URL does not belong to the bucket: " + bucketName);
+        }
+    }
+
+    public void deleteFile(String bucketName, String fileUrl) {
+        try {
+            String key = extractKeyFromUrl(bucketName, fileUrl);
+            DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(key)
+                    .build();
+
+            awsS3Client.deleteObject(deleteObjectRequest);
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            throw new AwsS3Exception(AwsS3ExceptionInfo.FILE_DELETE_FAILED);
+        }
+    }
+}

--- a/backend/src/main/java/com/beb/backend/service/AwsS3Service.java
+++ b/backend/src/main/java/com/beb/backend/service/AwsS3Service.java
@@ -23,40 +23,26 @@ public class AwsS3Service {
                     .key(filePath)
                     .contentType(multipartFile.getContentType())
                     .build();
-
             RequestBody requestBody = RequestBody.fromInputStream(multipartFile.getInputStream(), multipartFile.getSize());
 
             awsS3Client.putObject(putObjectRequest, requestBody);
         } catch (Exception e) {
             System.out.println(e.getMessage());
-            throw new AwsS3Exception(AwsS3ExceptionInfo.FILE_UPLOAD_FAILED);
+            throw new AwsS3Exception(AwsS3ExceptionInfo.S3_FILE_UPLOAD_FAILED);
         }
     }
 
-    private String extractKeyFromUrl(String bucketName, String fileUrl) {
-        // 버킷 URL 구성
-        String bucketUrl = "https://" + bucketName + ".s3.ap-northeast-2.amazonaws.com/";
-
-        // URL에서 Key 추출
-        if (fileUrl.startsWith(bucketUrl)) {
-            return fileUrl.substring(bucketUrl.length());
-        } else {
-            throw new IllegalArgumentException("URL does not belong to the bucket: " + bucketName);
-        }
-    }
-
-    public void deleteFile(String bucketName, String fileUrl) {
+    public void deleteFile(String bucketName, String filePath) {
         try {
-            String key = extractKeyFromUrl(bucketName, fileUrl);
             DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
                     .bucket(bucketName)
-                    .key(key)
+                    .key(filePath)
                     .build();
 
             awsS3Client.deleteObject(deleteObjectRequest);
         } catch (Exception e) {
             System.out.println(e.getMessage());
-            throw new AwsS3Exception(AwsS3ExceptionInfo.FILE_DELETE_FAILED);
+            throw new AwsS3Exception(AwsS3ExceptionInfo.S3_FILE_DELETE_FAILED);
         }
     }
 }

--- a/backend/src/main/java/com/beb/backend/service/MemberService.java
+++ b/backend/src/main/java/com/beb/backend/service/MemberService.java
@@ -157,7 +157,7 @@ public class MemberService {
                 member.getNickname(),
                 member.getAge(),
                 member.getGender(),
-                member.getProfileImgPath()
+                profileImgService.generateProfileImgUrl(member.getProfileImgKey())
         );
     }
 
@@ -187,7 +187,7 @@ public class MemberService {
         return memberRepository.findById(userId)
                 .map(member -> new PublicProfileDto(
                         member.getNickname(),
-                        member.getProfileImgPath()
+                        profileImgService.generateProfileImgUrl(member.getProfileImgKey())
                 ))
                 .orElseThrow(() -> new MemberException(MemberExceptionInfo.MEMBER_NOT_FOUND));
     }

--- a/backend/src/main/java/com/beb/backend/service/ProfileImgService.java
+++ b/backend/src/main/java/com/beb/backend/service/ProfileImgService.java
@@ -67,7 +67,8 @@ public class ProfileImgService {
         return profileImgKey;   // profileImgKey를 Member에 저장. 프론트 측에 제공할 때에는 URL로 바꿔서 제공
     }
 
-    public void deleteProfileImage(String profileImgKey) {
+    public String deleteProfileImage(String profileImgKey) {
         awsS3Service.deleteFile(BUCKET_NAME, profileImgKey);
+        return DEFAULT_PROFILE_IMG_KEY;
     }
 }

--- a/backend/src/main/java/com/beb/backend/service/ProfileImgService.java
+++ b/backend/src/main/java/com/beb/backend/service/ProfileImgService.java
@@ -19,7 +19,7 @@ public class ProfileImgService {
     private String REGION;
 
     private static final List<String> ALLOWED_EXTENSIONS = List.of(".jpg", ".jpeg", ".png");
-    private static final long MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+    private static final long MAX_FILE_SIZE = 1024 * 1024;  // 1MB
     private static final String BUCKET_NAME = "test-beb-bucket-01";
 
     public static final String DEFAULT_PROFILE_IMG_KEY = "profile-images/default";

--- a/backend/src/main/java/com/beb/backend/service/ProfileImgService.java
+++ b/backend/src/main/java/com/beb/backend/service/ProfileImgService.java
@@ -1,0 +1,73 @@
+package com.beb.backend.service;
+
+import com.beb.backend.exception.ProfileImgException;
+import com.beb.backend.exception.ProfileImgExceptionInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ProfileImgService {
+
+    private final AwsS3Service awsS3Service;
+
+    @Value("${cloud.aws.region}")
+    private String REGION;
+
+    private static final List<String> ALLOWED_EXTENSIONS = List.of(".jpg", ".jpeg", ".png");
+    private static final long MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+    private static final String BUCKET_NAME = "test-beb-bucket-01";
+
+    public static final String DEFAULT_PROFILE_IMG_KEY = "profile-images/default";
+
+    private void validateProfileImgFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new ProfileImgException(ProfileImgExceptionInfo.NULL_OR_EMPTY_FILE);
+        }
+        validateProfileImgSize(file.getSize());
+        validateProfileImgExtension(file.getOriginalFilename());
+    }
+
+    private void validateProfileImgExtension(String fileName) {
+        if (fileName == null || !fileName.contains(".")) {
+            throw new ProfileImgException(ProfileImgExceptionInfo.INVALID_FILE_EXTENSION);
+        }
+
+        String extension = fileName.substring(fileName.lastIndexOf(".")).toLowerCase();
+        if (!ALLOWED_EXTENSIONS.contains(extension)) {
+            throw new ProfileImgException(ProfileImgExceptionInfo.INVALID_FILE_EXTENSION);
+        }
+    }
+
+    private void validateProfileImgSize(long fileSize) {
+        if (fileSize > MAX_FILE_SIZE) {
+            throw new ProfileImgException(ProfileImgExceptionInfo.FILE_SIZE_LIMIT_EXCEEDED);
+        }
+    }
+
+    public String generateProfileImgUrl(String profileImgKey) {
+        if (profileImgKey == null) {
+            profileImgKey = DEFAULT_PROFILE_IMG_KEY;
+        }
+        return "https://" + BUCKET_NAME + ".s3." + REGION + ".amazonaws.com/" + profileImgKey;
+    }
+
+    public String uploadProfileImage(MultipartFile profileImg, long memberId) {
+        // 회원 가입 시, 회원 정보 수정 시 필요
+        // 회원 가입 시 -> memberId가 나와야 profileImgKey 설정 가능
+        // 회원 정보 수정 시 -> 파일이 없으면 기존 파일 있었을 경우 삭제해야 함.
+        validateProfileImgFile(profileImg);
+
+        String profileImgKey = "profile-images/" + memberId;
+        awsS3Service.uploadFile(BUCKET_NAME, profileImgKey, profileImg);
+        return profileImgKey;   // profileImgKey를 Member에 저장. 프론트 측에 제공할 때에는 URL로 바꿔서 제공
+    }
+
+    public void deleteProfileImage(String profileImgKey) {
+        awsS3Service.deleteFile(BUCKET_NAME, profileImgKey);
+    }
+}


### PR DESCRIPTION
### 1️⃣ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
<br>

### 2️⃣ 이슈 번호
- close #53 
<br>
<br>

### 3️⃣ 변경 사항
- [회원가입](https://www.notion.so/14591c17c5908183beb8ead1ac9945bf), [현재 사용자 프로필 수정](https://www.notion.so/14591c17c590817aab6aeecead206460)
  - 회원가입, 프로필 수정 시 프로필 이미지도 입력할 수 있도록 변경
  - request body의 Content-Type 을 `multipart/form-data` 타입으로 변경. 기존에 json으로 받던 텍스트 정보는 `userInfo`를 key로 한 json 형식의 값으로 입력하고, 프로필 이미지 파일은 `profileImg`를 key로 하여 파일을 입력해야 함
  - request 예시 이미지
  ![example](https://github.com/user-attachments/assets/e6349611-5c8d-41b3-bc51-f16fbd3d7167)
  - 자세한 내용은 링크로 연결된 api 명세서 참고

- [현재 사용자 프로필 조회](https://www.notion.so/1f8fe9d0c6534a3983e68f6e0d8d4694), [특정 사용자 프로필 조회](https://www.notion.so/1f191fa103ab44ff86ca211b49eefe7e)
  - response body json의 `profileImgPath` key를 `profileImgUrl`로 변경
<br>
<br>

### 4️⃣ 테스트 결과

